### PR TITLE
Bump NuGet package versions

### DIFF
--- a/Phase 1/src/02. EndSolution/Api/Api.csproj
+++ b/Phase 1/src/02. EndSolution/Api/Api.csproj
@@ -15,8 +15,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
 	</ItemGroup>
 

--- a/Phase 1/src/02. EndSolution/Core/Core.csproj
+++ b/Phase 1/src/02. EndSolution/Core/Core.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Phase 1/src/02. EndSolution/DataAccess/DataAccess.csproj
+++ b/Phase 1/src/02. EndSolution/DataAccess/DataAccess.csproj
@@ -8,9 +8,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Phase 1/src/02. EndSolution/Test/Test.csproj
+++ b/Phase 1/src/02. EndSolution/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 	</ItemGroup>

--- a/Phase 10/src/01. StartSolution/Api/Api.csproj
+++ b/Phase 10/src/01. StartSolution/Api/Api.csproj
@@ -13,11 +13,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.0" />
-        <PackageReference Include="Magick.NET.Core" Version="14.13.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
-        <PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
+        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.1" />
+        <PackageReference Include="Magick.NET.Core" Version="14.13.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+        <PackageReference Include="Microsoft.OpenApi" Version="3.5.3" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
     </ItemGroup>

--- a/Phase 10/src/01. StartSolution/Common/Common.csproj
+++ b/Phase 10/src/01. StartSolution/Common/Common.csproj
@@ -8,11 +8,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoMapper" Version="12.0.0" />
+        <PackageReference Include="AutoMapper" Version="16.1.1" />
         <PackageReference Include="FluentValidation" Version="12.1.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/Phase 10/src/01. StartSolution/Core/Core.csproj
+++ b/Phase 10/src/01. StartSolution/Core/Core.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoMapper" Version="12.0.0" />
-        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
+        <PackageReference Include="AutoMapper" Version="16.1.1" />
+        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
         <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />

--- a/Phase 10/src/01. StartSolution/DataAccess/DataAccess.csproj
+++ b/Phase 10/src/01. StartSolution/DataAccess/DataAccess.csproj
@@ -9,12 +9,12 @@
 
     <ItemGroup>
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 10/src/01. StartSolution/Test/Test.csproj
+++ b/Phase 10/src/01. StartSolution/Test/Test.csproj
@@ -17,8 +17,8 @@
 
     <ItemGroup>
         <PackageReference Include="Bogus" Version="35.6.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-        <PackageReference Include="nunit" Version="4.6.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+        <PackageReference Include="nunit" Version="4.6.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 10/src/01. StartSolution/Utilities/Utilities.csproj
+++ b/Phase 10/src/01. StartSolution/Utilities/Utilities.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="MediatR" Version="14.1.0" />
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/Phase 10/src/02. FinalSolution/Api/Api.csproj
+++ b/Phase 10/src/02. FinalSolution/Api/Api.csproj
@@ -13,10 +13,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.0" />
-        <PackageReference Include="Magick.NET.Core" Version="14.13.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.1" />
+        <PackageReference Include="Magick.NET.Core" Version="14.13.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="OpenTelemetry" Version="1.15.3" />
         <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
@@ -29,7 +29,7 @@
         <PackageReference Include="Serilog.Enrichers.Correlate" Version="1.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-        <PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
+        <PackageReference Include="Microsoft.OpenApi" Version="3.5.3" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
     </ItemGroup>
 

--- a/Phase 10/src/02. FinalSolution/AspireHost/AspireHost.csproj
+++ b/Phase 10/src/02. FinalSolution/AspireHost/AspireHost.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.0" />
-        <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.0" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.5" />
+        <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.5" />
         <PackageReference Include="OpenTelemetry" Version="1.15.3" />
     </ItemGroup>
 

--- a/Phase 10/src/02. FinalSolution/Common/Common.csproj
+++ b/Phase 10/src/02. FinalSolution/Common/Common.csproj
@@ -9,9 +9,9 @@
 
     <ItemGroup>
         <PackageReference Include="FluentValidation" Version="12.1.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/Phase 10/src/02. FinalSolution/DataAccess/DataAccess.csproj
+++ b/Phase 10/src/02. FinalSolution/DataAccess/DataAccess.csproj
@@ -9,12 +9,12 @@
 
     <ItemGroup>
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 10/src/02. FinalSolution/Test/Test.csproj
+++ b/Phase 10/src/02. FinalSolution/Test/Test.csproj
@@ -17,8 +17,8 @@
 
     <ItemGroup>
         <PackageReference Include="Bogus" Version="35.6.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-        <PackageReference Include="nunit" Version="4.6.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+        <PackageReference Include="nunit" Version="4.6.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 10/src/02. FinalSolution/Utilities/Utilities.csproj
+++ b/Phase 10/src/02. FinalSolution/Utilities/Utilities.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="MediatR" Version="14.1.0" />
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/Phase 11/src/01. StartSolution/Api/Api.csproj
+++ b/Phase 11/src/01. StartSolution/Api/Api.csproj
@@ -13,11 +13,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.0" />
-        <PackageReference Include="Magick.NET.Core" Version="14.13.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
-        <PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
+        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.1" />
+        <PackageReference Include="Magick.NET.Core" Version="14.13.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+        <PackageReference Include="Microsoft.OpenApi" Version="3.5.3" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="OpenTelemetry" Version="1.15.3" />
         <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />

--- a/Phase 11/src/01. StartSolution/AspireHost/AspireHost.csproj
+++ b/Phase 11/src/01. StartSolution/AspireHost/AspireHost.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.0" />
-        <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.0" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.5" />
+        <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.5" />
         <PackageReference Include="OpenTelemetry" Version="1.15.3" />
     </ItemGroup>
 

--- a/Phase 11/src/01. StartSolution/Common/Common.csproj
+++ b/Phase 11/src/01. StartSolution/Common/Common.csproj
@@ -9,9 +9,9 @@
 
     <ItemGroup>
         <PackageReference Include="FluentValidation" Version="12.1.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/Phase 11/src/01. StartSolution/DataAccess/DataAccess.csproj
+++ b/Phase 11/src/01. StartSolution/DataAccess/DataAccess.csproj
@@ -9,12 +9,12 @@
 
     <ItemGroup>
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 11/src/01. StartSolution/Test/Test.csproj
+++ b/Phase 11/src/01. StartSolution/Test/Test.csproj
@@ -17,8 +17,8 @@
 
     <ItemGroup>
         <PackageReference Include="Bogus" Version="35.6.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-        <PackageReference Include="nunit" Version="4.6.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+        <PackageReference Include="nunit" Version="4.6.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 11/src/01. StartSolution/Utilities/Utilities.csproj
+++ b/Phase 11/src/01. StartSolution/Utilities/Utilities.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="MediatR" Version="14.1.0" />
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/Phase 11/src/02. FinalSolution/Api/Api.csproj
+++ b/Phase 11/src/02. FinalSolution/Api/Api.csproj
@@ -13,11 +13,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.0" />
-        <PackageReference Include="Magick.NET.Core" Version="14.13.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
-        <PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
+        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.1" />
+        <PackageReference Include="Magick.NET.Core" Version="14.13.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+        <PackageReference Include="Microsoft.OpenApi" Version="3.5.3" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="OpenTelemetry" Version="1.15.3" />
         <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />

--- a/Phase 11/src/02. FinalSolution/AspireHost/AspireHost.csproj
+++ b/Phase 11/src/02. FinalSolution/AspireHost/AspireHost.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.0" />
-        <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.0" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.5" />
+        <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.5" />
         <PackageReference Include="OpenTelemetry" Version="1.15.3" />
     </ItemGroup>
 

--- a/Phase 11/src/02. FinalSolution/Common/Common.csproj
+++ b/Phase 11/src/02. FinalSolution/Common/Common.csproj
@@ -9,9 +9,9 @@
 
     <ItemGroup>
         <PackageReference Include="FluentValidation" Version="12.1.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/Phase 11/src/02. FinalSolution/DataAccess/DataAccess.csproj
+++ b/Phase 11/src/02. FinalSolution/DataAccess/DataAccess.csproj
@@ -9,12 +9,12 @@
 
     <ItemGroup>
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 11/src/02. FinalSolution/Test/Test.csproj
+++ b/Phase 11/src/02. FinalSolution/Test/Test.csproj
@@ -17,8 +17,8 @@
 
     <ItemGroup>
         <PackageReference Include="Bogus" Version="35.6.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-        <PackageReference Include="nunit" Version="4.6.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+        <PackageReference Include="nunit" Version="4.6.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 11/src/02. FinalSolution/Utilities/Utilities.csproj
+++ b/Phase 11/src/02. FinalSolution/Utilities/Utilities.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="MediatR" Version="14.1.0" />
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/Phase 12/src/01. StartSolution/Api/Api.csproj
+++ b/Phase 12/src/01. StartSolution/Api/Api.csproj
@@ -13,11 +13,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.0" />
-        <PackageReference Include="Magick.NET.Core" Version="14.13.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
-        <PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
+        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.1" />
+        <PackageReference Include="Magick.NET.Core" Version="14.13.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+        <PackageReference Include="Microsoft.OpenApi" Version="3.5.3" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="OpenTelemetry" Version="1.15.3" />
         <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />

--- a/Phase 12/src/01. StartSolution/AspireHost/AspireHost.csproj
+++ b/Phase 12/src/01. StartSolution/AspireHost/AspireHost.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.0" />
-        <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.0" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.5" />
+        <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.5" />
         <PackageReference Include="OpenTelemetry" Version="1.15.3" />
     </ItemGroup>
 

--- a/Phase 12/src/01. StartSolution/Common/Common.csproj
+++ b/Phase 12/src/01. StartSolution/Common/Common.csproj
@@ -9,9 +9,9 @@
 
     <ItemGroup>
         <PackageReference Include="FluentValidation" Version="12.1.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/Phase 12/src/01. StartSolution/DataAccess/DataAccess.csproj
+++ b/Phase 12/src/01. StartSolution/DataAccess/DataAccess.csproj
@@ -9,12 +9,12 @@
 
     <ItemGroup>
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 12/src/01. StartSolution/Test/Test.csproj
+++ b/Phase 12/src/01. StartSolution/Test/Test.csproj
@@ -17,8 +17,8 @@
 
     <ItemGroup>
         <PackageReference Include="Bogus" Version="35.6.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-        <PackageReference Include="nunit" Version="4.6.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+        <PackageReference Include="nunit" Version="4.6.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 12/src/01. StartSolution/Utilities/Utilities.csproj
+++ b/Phase 12/src/01. StartSolution/Utilities/Utilities.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="MediatR" Version="14.1.0" />
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/Phase 12/src/02. FinalSolution/Api/Api.csproj
+++ b/Phase 12/src/02. FinalSolution/Api/Api.csproj
@@ -13,11 +13,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.0" />
-        <PackageReference Include="Magick.NET.Core" Version="14.13.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
-        <PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
+        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.1" />
+        <PackageReference Include="Magick.NET.Core" Version="14.13.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+        <PackageReference Include="Microsoft.OpenApi" Version="3.5.3" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="OpenTelemetry" Version="1.15.3" />
         <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />

--- a/Phase 12/src/02. FinalSolution/AspireHost/AspireHost.csproj
+++ b/Phase 12/src/02. FinalSolution/AspireHost/AspireHost.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.0" />
-        <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.0" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.5" />
+        <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.5" />
         <PackageReference Include="OpenTelemetry" Version="1.15.3" />
     </ItemGroup>
 

--- a/Phase 12/src/02. FinalSolution/Common/Common.csproj
+++ b/Phase 12/src/02. FinalSolution/Common/Common.csproj
@@ -9,9 +9,9 @@
 
     <ItemGroup>
         <PackageReference Include="FluentValidation" Version="12.1.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/Phase 12/src/02. FinalSolution/DataAccess/DataAccess.csproj
+++ b/Phase 12/src/02. FinalSolution/DataAccess/DataAccess.csproj
@@ -9,12 +9,12 @@
 
     <ItemGroup>
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 12/src/02. FinalSolution/DbUp.Migrations/DbUp.Migrations.csproj
+++ b/Phase 12/src/02. FinalSolution/DbUp.Migrations/DbUp.Migrations.csproj
@@ -9,8 +9,8 @@
 
     <ItemGroup>
         <PackageReference Include="dbup-sqlserver" Version="7.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     </ItemGroup>

--- a/Phase 12/src/02. FinalSolution/Test/Test.csproj
+++ b/Phase 12/src/02. FinalSolution/Test/Test.csproj
@@ -17,8 +17,8 @@
 
     <ItemGroup>
         <PackageReference Include="Bogus" Version="35.6.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-        <PackageReference Include="nunit" Version="4.6.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+        <PackageReference Include="nunit" Version="4.6.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 12/src/02. FinalSolution/Utilities/Utilities.csproj
+++ b/Phase 12/src/02. FinalSolution/Utilities/Utilities.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="MediatR" Version="14.1.0" />
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/Phase 13/src/01. StartSolution/Api/Api.csproj
+++ b/Phase 13/src/01. StartSolution/Api/Api.csproj
@@ -13,11 +13,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.0" />
-        <PackageReference Include="Magick.NET.Core" Version="14.13.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
-        <PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
+        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.1" />
+        <PackageReference Include="Magick.NET.Core" Version="14.13.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+        <PackageReference Include="Microsoft.OpenApi" Version="3.5.3" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="OpenTelemetry" Version="1.15.3" />
         <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />

--- a/Phase 13/src/01. StartSolution/AspireHost/AspireHost.csproj
+++ b/Phase 13/src/01. StartSolution/AspireHost/AspireHost.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.0" />
-        <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.0" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.5" />
+        <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.5" />
         <PackageReference Include="OpenTelemetry" Version="1.15.3" />
     </ItemGroup>
 

--- a/Phase 13/src/01. StartSolution/Common/Common.csproj
+++ b/Phase 13/src/01. StartSolution/Common/Common.csproj
@@ -9,9 +9,9 @@
 
     <ItemGroup>
         <PackageReference Include="FluentValidation" Version="12.1.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/Phase 13/src/01. StartSolution/DataAccess/DataAccess.csproj
+++ b/Phase 13/src/01. StartSolution/DataAccess/DataAccess.csproj
@@ -9,12 +9,12 @@
 
     <ItemGroup>
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 13/src/01. StartSolution/DbUp.Migrations/DbUp.Migrations.csproj
+++ b/Phase 13/src/01. StartSolution/DbUp.Migrations/DbUp.Migrations.csproj
@@ -9,8 +9,8 @@
 
     <ItemGroup>
         <PackageReference Include="dbup-sqlserver" Version="7.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     </ItemGroup>

--- a/Phase 13/src/01. StartSolution/Test/Test.csproj
+++ b/Phase 13/src/01. StartSolution/Test/Test.csproj
@@ -17,8 +17,8 @@
 
     <ItemGroup>
         <PackageReference Include="Bogus" Version="35.6.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-        <PackageReference Include="nunit" Version="4.6.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+        <PackageReference Include="nunit" Version="4.6.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 13/src/01. StartSolution/Utilities/Utilities.csproj
+++ b/Phase 13/src/01. StartSolution/Utilities/Utilities.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="MediatR" Version="14.1.0" />
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/Phase 13/src/02. FinalSolution/Api/Api.csproj
+++ b/Phase 13/src/02. FinalSolution/Api/Api.csproj
@@ -13,11 +13,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.0" />
-        <PackageReference Include="Magick.NET.Core" Version="14.13.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
-        <PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
+        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.1" />
+        <PackageReference Include="Magick.NET.Core" Version="14.13.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+        <PackageReference Include="Microsoft.OpenApi" Version="3.5.3" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="OpenTelemetry" Version="1.15.3" />
         <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />

--- a/Phase 13/src/02. FinalSolution/AspireHost/AspireHost.csproj
+++ b/Phase 13/src/02. FinalSolution/AspireHost/AspireHost.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.0" />
-        <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.0" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.5" />
+        <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.5" />
         <PackageReference Include="OpenTelemetry" Version="1.15.3" />
     </ItemGroup>
 

--- a/Phase 13/src/02. FinalSolution/Common/Common.csproj
+++ b/Phase 13/src/02. FinalSolution/Common/Common.csproj
@@ -9,9 +9,9 @@
 
     <ItemGroup>
         <PackageReference Include="FluentValidation" Version="12.1.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/Phase 13/src/02. FinalSolution/DataAccess/DataAccess.csproj
+++ b/Phase 13/src/02. FinalSolution/DataAccess/DataAccess.csproj
@@ -9,12 +9,12 @@
 
     <ItemGroup>
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 13/src/02. FinalSolution/DbUp.Migrations/DbUp.Migrations.csproj
+++ b/Phase 13/src/02. FinalSolution/DbUp.Migrations/DbUp.Migrations.csproj
@@ -9,8 +9,8 @@
 
     <ItemGroup>
         <PackageReference Include="dbup-sqlserver" Version="7.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     </ItemGroup>

--- a/Phase 13/src/02. FinalSolution/Mcp/Mcp.csproj
+++ b/Phase 13/src/02. FinalSolution/Mcp/Mcp.csproj
@@ -8,9 +8,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     </ItemGroup>

--- a/Phase 13/src/02. FinalSolution/Test/Test.csproj
+++ b/Phase 13/src/02. FinalSolution/Test/Test.csproj
@@ -17,8 +17,8 @@
 
     <ItemGroup>
         <PackageReference Include="Bogus" Version="35.6.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-        <PackageReference Include="nunit" Version="4.6.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+        <PackageReference Include="nunit" Version="4.6.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 13/src/02. FinalSolution/Utilities/Utilities.csproj
+++ b/Phase 13/src/02. FinalSolution/Utilities/Utilities.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="MediatR" Version="14.1.0" />
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/Phase 14/src/01. StartSolution/Api/Api.csproj
+++ b/Phase 14/src/01. StartSolution/Api/Api.csproj
@@ -13,11 +13,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.0" />
-        <PackageReference Include="Magick.NET.Core" Version="14.13.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
-        <PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
+        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.1" />
+        <PackageReference Include="Magick.NET.Core" Version="14.13.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+        <PackageReference Include="Microsoft.OpenApi" Version="3.5.3" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="OpenTelemetry" Version="1.15.3" />
         <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />

--- a/Phase 14/src/01. StartSolution/AspireHost/AspireHost.csproj
+++ b/Phase 14/src/01. StartSolution/AspireHost/AspireHost.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.0" />
-        <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.0" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.5" />
+        <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.5" />
         <PackageReference Include="OpenTelemetry" Version="1.15.3" />
     </ItemGroup>
 

--- a/Phase 14/src/01. StartSolution/Common/Common.csproj
+++ b/Phase 14/src/01. StartSolution/Common/Common.csproj
@@ -9,9 +9,9 @@
 
     <ItemGroup>
         <PackageReference Include="FluentValidation" Version="12.1.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/Phase 14/src/01. StartSolution/DataAccess/DataAccess.csproj
+++ b/Phase 14/src/01. StartSolution/DataAccess/DataAccess.csproj
@@ -9,12 +9,12 @@
 
     <ItemGroup>
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 14/src/01. StartSolution/DbUp.Migrations/DbUp.Migrations.csproj
+++ b/Phase 14/src/01. StartSolution/DbUp.Migrations/DbUp.Migrations.csproj
@@ -9,8 +9,8 @@
 
     <ItemGroup>
         <PackageReference Include="dbup-sqlserver" Version="7.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     </ItemGroup>

--- a/Phase 14/src/01. StartSolution/Mcp/Mcp.csproj
+++ b/Phase 14/src/01. StartSolution/Mcp/Mcp.csproj
@@ -8,9 +8,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     </ItemGroup>

--- a/Phase 14/src/01. StartSolution/Test/Test.csproj
+++ b/Phase 14/src/01. StartSolution/Test/Test.csproj
@@ -17,8 +17,8 @@
 
     <ItemGroup>
         <PackageReference Include="Bogus" Version="35.6.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-        <PackageReference Include="nunit" Version="4.6.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+        <PackageReference Include="nunit" Version="4.6.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 14/src/01. StartSolution/Utilities/Utilities.csproj
+++ b/Phase 14/src/01. StartSolution/Utilities/Utilities.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="MediatR" Version="14.1.0" />
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/Phase 14/src/02. FinalSolution/Api/Api.csproj
+++ b/Phase 14/src/02. FinalSolution/Api/Api.csproj
@@ -13,11 +13,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.0" />
-        <PackageReference Include="Magick.NET.Core" Version="14.13.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
-        <PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
+        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.1" />
+        <PackageReference Include="Magick.NET.Core" Version="14.13.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+        <PackageReference Include="Microsoft.OpenApi" Version="3.5.3" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="OpenTelemetry" Version="1.15.3" />
         <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
@@ -30,7 +30,7 @@
         <PackageReference Include="Serilog.Enrichers.Correlate" Version="1.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
         <PackageReference Include="Polly" Version="8.6.6" />
         <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />

--- a/Phase 14/src/02. FinalSolution/AspireHost/AspireHost.csproj
+++ b/Phase 14/src/02. FinalSolution/AspireHost/AspireHost.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.0" />
-        <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.0" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.5" />
+        <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.5" />
         <PackageReference Include="OpenTelemetry" Version="1.15.3" />
     </ItemGroup>
 

--- a/Phase 14/src/02. FinalSolution/Common/Common.csproj
+++ b/Phase 14/src/02. FinalSolution/Common/Common.csproj
@@ -9,9 +9,9 @@
 
     <ItemGroup>
         <PackageReference Include="FluentValidation" Version="12.1.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/Phase 14/src/02. FinalSolution/Core/Core.csproj
+++ b/Phase 14/src/02. FinalSolution/Core/Core.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
         <PackageReference Include="Polly" Version="8.6.6" />
         <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
         <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />

--- a/Phase 14/src/02. FinalSolution/DataAccess/DataAccess.csproj
+++ b/Phase 14/src/02. FinalSolution/DataAccess/DataAccess.csproj
@@ -9,12 +9,12 @@
 
     <ItemGroup>
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 14/src/02. FinalSolution/DbUp.Migrations/DbUp.Migrations.csproj
+++ b/Phase 14/src/02. FinalSolution/DbUp.Migrations/DbUp.Migrations.csproj
@@ -9,8 +9,8 @@
 
     <ItemGroup>
         <PackageReference Include="dbup-sqlserver" Version="7.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     </ItemGroup>

--- a/Phase 14/src/02. FinalSolution/Mcp/Mcp.csproj
+++ b/Phase 14/src/02. FinalSolution/Mcp/Mcp.csproj
@@ -8,9 +8,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     </ItemGroup>

--- a/Phase 14/src/02. FinalSolution/Test/Test.csproj
+++ b/Phase 14/src/02. FinalSolution/Test/Test.csproj
@@ -19,8 +19,8 @@
     <ItemGroup>
         <PackageReference Include="Bogus" Version="35.6.5" />
         <PackageReference Include="Imposter" Version="0.1.9" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-        <PackageReference Include="nunit" Version="4.6.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+        <PackageReference Include="nunit" Version="4.6.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 14/src/02. FinalSolution/Utilities/Utilities.csproj
+++ b/Phase 14/src/02. FinalSolution/Utilities/Utilities.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="MediatR" Version="14.1.0" />
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/Phase 15/src/01. StartSolution/Api/Api.csproj
+++ b/Phase 15/src/01. StartSolution/Api/Api.csproj
@@ -13,11 +13,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.0" />
-        <PackageReference Include="Magick.NET.Core" Version="14.13.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
-        <PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
+        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.1" />
+        <PackageReference Include="Magick.NET.Core" Version="14.13.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+        <PackageReference Include="Microsoft.OpenApi" Version="3.5.3" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="OpenTelemetry" Version="1.15.3" />
         <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
@@ -30,7 +30,7 @@
         <PackageReference Include="Serilog.Enrichers.Correlate" Version="1.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
         <PackageReference Include="Polly" Version="8.6.6" />
         <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />

--- a/Phase 15/src/01. StartSolution/AspireHost/AspireHost.csproj
+++ b/Phase 15/src/01. StartSolution/AspireHost/AspireHost.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.0" />
-        <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.0" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.5" />
+        <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.3.5" />
         <PackageReference Include="OpenTelemetry" Version="1.15.3" />
     </ItemGroup>
 

--- a/Phase 15/src/01. StartSolution/Common/Common.csproj
+++ b/Phase 15/src/01. StartSolution/Common/Common.csproj
@@ -9,9 +9,9 @@
 
     <ItemGroup>
         <PackageReference Include="FluentValidation" Version="12.1.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/Phase 15/src/01. StartSolution/Core/Core.csproj
+++ b/Phase 15/src/01. StartSolution/Core/Core.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
         <PackageReference Include="Polly" Version="8.6.6" />
         <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
         <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />

--- a/Phase 15/src/01. StartSolution/DataAccess/DataAccess.csproj
+++ b/Phase 15/src/01. StartSolution/DataAccess/DataAccess.csproj
@@ -9,12 +9,12 @@
 
     <ItemGroup>
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 15/src/01. StartSolution/DbUp.Migrations/DbUp.Migrations.csproj
+++ b/Phase 15/src/01. StartSolution/DbUp.Migrations/DbUp.Migrations.csproj
@@ -9,8 +9,8 @@
 
     <ItemGroup>
         <PackageReference Include="dbup-sqlserver" Version="7.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     </ItemGroup>

--- a/Phase 15/src/01. StartSolution/Mcp/Mcp.csproj
+++ b/Phase 15/src/01. StartSolution/Mcp/Mcp.csproj
@@ -8,9 +8,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     </ItemGroup>

--- a/Phase 15/src/01. StartSolution/Test/Test.csproj
+++ b/Phase 15/src/01. StartSolution/Test/Test.csproj
@@ -19,8 +19,8 @@
     <ItemGroup>
         <PackageReference Include="Bogus" Version="35.6.5" />
         <PackageReference Include="Imposter" Version="0.1.9" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-        <PackageReference Include="nunit" Version="4.6.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+        <PackageReference Include="nunit" Version="4.6.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 15/src/01. StartSolution/Utilities/Utilities.csproj
+++ b/Phase 15/src/01. StartSolution/Utilities/Utilities.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="MediatR" Version="14.1.0" />
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/Phase 2/src/01. StartSolution/Api/Api.csproj
+++ b/Phase 2/src/01. StartSolution/Api/Api.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
 	</ItemGroup>
 

--- a/Phase 2/src/01. StartSolution/Common/Common.csproj
+++ b/Phase 2/src/01. StartSolution/Common/Common.csproj
@@ -14,6 +14,6 @@
 	<ItemGroup>
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
 	  <PackageReference Include="FluentValidation" Version="12.1.1" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 	</ItemGroup>
 </Project>

--- a/Phase 2/src/01. StartSolution/DataAccess/DataAccess.csproj
+++ b/Phase 2/src/01. StartSolution/DataAccess/DataAccess.csproj
@@ -8,9 +8,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Phase 2/src/01. StartSolution/Test/Test.csproj
+++ b/Phase 2/src/01. StartSolution/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 	</ItemGroup>

--- a/Phase 2/src/02. EndSolution/Api/Api.csproj
+++ b/Phase 2/src/02. EndSolution/Api/Api.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
 	</ItemGroup>
 

--- a/Phase 2/src/02. EndSolution/DataAccess/DataAccess.csproj
+++ b/Phase 2/src/02. EndSolution/DataAccess/DataAccess.csproj
@@ -8,9 +8,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Phase 2/src/02. EndSolution/Test/Test.csproj
+++ b/Phase 2/src/02. EndSolution/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 	</ItemGroup>

--- a/Phase 3/src/01. StartSolution/Api/Api.csproj
+++ b/Phase 3/src/01. StartSolution/Api/Api.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
 	</ItemGroup>
 

--- a/Phase 3/src/01. StartSolution/Common/Common.csproj
+++ b/Phase 3/src/01. StartSolution/Common/Common.csproj
@@ -14,6 +14,6 @@
 
 	<ItemGroup>
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 	</ItemGroup>
 </Project>

--- a/Phase 3/src/01. StartSolution/DataAccess/DataAccess.csproj
+++ b/Phase 3/src/01. StartSolution/DataAccess/DataAccess.csproj
@@ -8,9 +8,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Phase 3/src/01. StartSolution/Test/Test.csproj
+++ b/Phase 3/src/01. StartSolution/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 	</ItemGroup>

--- a/Phase 3/src/02. Step1/Api/Api.csproj
+++ b/Phase 3/src/02. Step1/Api/Api.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
 	</ItemGroup>
 

--- a/Phase 3/src/02. Step1/Common/Common.csproj
+++ b/Phase 3/src/02. Step1/Common/Common.csproj
@@ -14,6 +14,6 @@
 
 	<ItemGroup>
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 	</ItemGroup>
 </Project>

--- a/Phase 3/src/02. Step1/Core/Core.csproj
+++ b/Phase 3/src/02. Step1/Core/Core.csproj
@@ -18,7 +18,7 @@
 	<ItemGroup>
 	  <PackageReference Include="FluentValidation" Version="12.1.1" />
 	  <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-	  <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.10" />
 	  <PackageReference Include="Scrutor" Version="7.0.0" />
 	</ItemGroup>
 </Project>

--- a/Phase 3/src/02. Step1/DataAccess/DataAccess.csproj
+++ b/Phase 3/src/02. Step1/DataAccess/DataAccess.csproj
@@ -8,9 +8,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Phase 3/src/02. Step1/Test/Test.csproj
+++ b/Phase 3/src/02. Step1/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 	</ItemGroup>

--- a/Phase 3/src/03. EndSolution/Api/Api.csproj
+++ b/Phase 3/src/03. EndSolution/Api/Api.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
 	</ItemGroup>
 

--- a/Phase 3/src/03. EndSolution/Common/Common.csproj
+++ b/Phase 3/src/03. EndSolution/Common/Common.csproj
@@ -13,7 +13,7 @@
 
 	<ItemGroup>
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Phase 3/src/03. EndSolution/DataAccess/DataAccess.csproj
+++ b/Phase 3/src/03. EndSolution/DataAccess/DataAccess.csproj
@@ -8,9 +8,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Phase 3/src/03. EndSolution/Test/Test.csproj
+++ b/Phase 3/src/03. EndSolution/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 	</ItemGroup>

--- a/Phase 3/src/03. EndSolution/Utilities/Utilities.csproj
+++ b/Phase 3/src/03. EndSolution/Utilities/Utilities.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/Phase 4/src/01. StartSolution/Api/Api.csproj
+++ b/Phase 4/src/01. StartSolution/Api/Api.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
 	</ItemGroup>
 

--- a/Phase 4/src/01. StartSolution/Common/Common.csproj
+++ b/Phase 4/src/01. StartSolution/Common/Common.csproj
@@ -13,7 +13,7 @@
 
 	<ItemGroup>
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Phase 4/src/01. StartSolution/DataAccess/DataAccess.csproj
+++ b/Phase 4/src/01. StartSolution/DataAccess/DataAccess.csproj
@@ -8,9 +8,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Phase 4/src/01. StartSolution/Test/Test.csproj
+++ b/Phase 4/src/01. StartSolution/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 	</ItemGroup>

--- a/Phase 4/src/01. StartSolution/Utilities/Utilities.csproj
+++ b/Phase 4/src/01. StartSolution/Utilities/Utilities.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/Phase 4/src/02. Step1/Api/Api.csproj
+++ b/Phase 4/src/02. Step1/Api/Api.csproj
@@ -15,8 +15,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+		<PackageReference Include="Microsoft.OpenApi" Version="3.5.3" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
 	</ItemGroup>
 

--- a/Phase 4/src/02. Step1/Common/Common.csproj
+++ b/Phase 4/src/02. Step1/Common/Common.csproj
@@ -13,8 +13,8 @@
 
 	<ItemGroup>
 	  <PackageReference Include="FluentValidation" Version="12.1.1" />
-	  <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.10" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Phase 4/src/02. Step1/DataAccess/DataAccess.csproj
+++ b/Phase 4/src/02. Step1/DataAccess/DataAccess.csproj
@@ -8,9 +8,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Phase 4/src/02. Step1/Test/Test.csproj
+++ b/Phase 4/src/02. Step1/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 	</ItemGroup>

--- a/Phase 4/src/02. Step1/Utilities/Utilities.csproj
+++ b/Phase 4/src/02. Step1/Utilities/Utilities.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/Phase 4/src/03. Step2/Api/Api.csproj
+++ b/Phase 4/src/03. Step2/Api/Api.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
 	</ItemGroup>
 

--- a/Phase 4/src/03. Step2/Common/Common.csproj
+++ b/Phase 4/src/03. Step2/Common/Common.csproj
@@ -13,7 +13,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="FluentValidation" Version="12.1.1" />
-	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.10" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 	</ItemGroup>
 </Project>

--- a/Phase 4/src/03. Step2/DataAccess/DataAccess.csproj
+++ b/Phase 4/src/03. Step2/DataAccess/DataAccess.csproj
@@ -8,9 +8,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Phase 4/src/03. Step2/Test/Test.csproj
+++ b/Phase 4/src/03. Step2/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 	</ItemGroup>

--- a/Phase 5/src/01. StartSolution/Api/Api.csproj
+++ b/Phase 5/src/01. StartSolution/Api/Api.csproj
@@ -15,8 +15,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
-		<PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+		<PackageReference Include="Microsoft.OpenApi" Version="3.5.3" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
 	</ItemGroup>
 

--- a/Phase 5/src/01. StartSolution/Common/Common.csproj
+++ b/Phase 5/src/01. StartSolution/Common/Common.csproj
@@ -14,7 +14,7 @@
 	<ItemGroup>
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
 	  <PackageReference Include="FluentValidation" Version="12.1.1" />
-	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.10" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 	</ItemGroup>
 </Project>

--- a/Phase 5/src/01. StartSolution/DataAccess/DataAccess.csproj
+++ b/Phase 5/src/01. StartSolution/DataAccess/DataAccess.csproj
@@ -8,9 +8,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Phase 5/src/01. StartSolution/Test/Test.csproj
+++ b/Phase 5/src/01. StartSolution/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 	</ItemGroup>

--- a/Phase 5/src/02. Step 1/Api/Api.csproj
+++ b/Phase 5/src/02. Step 1/Api/Api.csproj
@@ -20,7 +20,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 5/src/02. Step 1/Common/Common.csproj
+++ b/Phase 5/src/02. Step 1/Common/Common.csproj
@@ -15,8 +15,8 @@
 	<ItemGroup>
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
 	  <PackageReference Include="FluentValidation" Version="12.1.1" />
-	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.10" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 	  <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 5/src/02. Step 1/DataAccess/DataAccess.csproj
+++ b/Phase 5/src/02. Step 1/DataAccess/DataAccess.csproj
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 5/src/02. Step 1/Test/Test.csproj
+++ b/Phase 5/src/02. Step 1/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 5/src/03. EndSolution/Api/Api.csproj
+++ b/Phase 5/src/03. EndSolution/Api/Api.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="All" Version="1.1.0.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
 	</ItemGroup>
 

--- a/Phase 5/src/03. EndSolution/Common/Common.csproj
+++ b/Phase 5/src/03. EndSolution/Common/Common.csproj
@@ -14,8 +14,8 @@
 	<ItemGroup>
 	  <PackageReference Include="All" Version="1.1.0.1" />
 	  <PackageReference Include="FluentValidation" Version="12.1.1" />
-	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.10" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 	  <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
 	  <PackageReference Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
 	</ItemGroup>

--- a/Phase 5/src/03. EndSolution/Core/Core.csproj
+++ b/Phase 5/src/03. EndSolution/Core/Core.csproj
@@ -10,7 +10,7 @@
 	<ItemGroup>
 	  <PackageReference Include="FluentValidation" Version="12.1.1" />
 	  <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-	  <PackageReference Include="LiteBus" Version="4.3.0" />
+	  <PackageReference Include="LiteBus" Version="4.4.0" />
 	  <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.2" />
 	</ItemGroup>
 

--- a/Phase 5/src/03. EndSolution/DataAccess/DataAccess.csproj
+++ b/Phase 5/src/03. EndSolution/DataAccess/DataAccess.csproj
@@ -8,9 +8,9 @@
 </PropertyGroup>
 
 <ItemGroup>
-<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 </ItemGroup>
 
 <ItemGroup>

--- a/Phase 5/src/03. EndSolution/Test/Test.csproj
+++ b/Phase 5/src/03. EndSolution/Test/Test.csproj
@@ -16,7 +16,7 @@
 	<ItemGroup>
 		<PackageReference Include="2" Version="2.0.0" />
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 	</ItemGroup>

--- a/Phase 6/src/01. StartSolution/Api/Api.csproj
+++ b/Phase 6/src/01. StartSolution/Api/Api.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="All" Version="1.1.0.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
 	</ItemGroup>
 

--- a/Phase 6/src/01. StartSolution/Common/Common.csproj
+++ b/Phase 6/src/01. StartSolution/Common/Common.csproj
@@ -14,8 +14,8 @@
 	<ItemGroup>
 	  <PackageReference Include="All" Version="1.1.0.1" />
 	  <PackageReference Include="FluentValidation" Version="12.1.1" />
-	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.10" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 	  <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
 	  <PackageReference Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
 	</ItemGroup>

--- a/Phase 6/src/01. StartSolution/Core/Core.csproj
+++ b/Phase 6/src/01. StartSolution/Core/Core.csproj
@@ -10,7 +10,7 @@
 	<ItemGroup>
 	  <PackageReference Include="FluentValidation" Version="12.1.1" />
 	  <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-	  <PackageReference Include="LiteBus" Version="4.3.0" />
+	  <PackageReference Include="LiteBus" Version="4.4.0" />
 	  <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.2" />
 	</ItemGroup>
 

--- a/Phase 6/src/01. StartSolution/DataAccess/DataAccess.csproj
+++ b/Phase 6/src/01. StartSolution/DataAccess/DataAccess.csproj
@@ -8,9 +8,9 @@
 </PropertyGroup>
 
 <ItemGroup>
-<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 </ItemGroup>
 
 <ItemGroup>

--- a/Phase 6/src/01. StartSolution/Test/Test.csproj
+++ b/Phase 6/src/01. StartSolution/Test/Test.csproj
@@ -16,7 +16,7 @@
 	<ItemGroup>
 		<PackageReference Include="2" Version="2.0.0" />
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 	</ItemGroup>

--- a/Phase 6/src/02. Step 1/Api/Api.csproj
+++ b/Phase 6/src/02. Step 1/Api/Api.csproj
@@ -18,13 +18,13 @@
 
 	<ItemGroup>
 		<PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
-		<PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
+		<PackageReference Include="Microsoft.OpenApi" Version="3.5.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Phase 6/src/02. Step 1/Common/Common.csproj
+++ b/Phase 6/src/02. Step 1/Common/Common.csproj
@@ -15,8 +15,8 @@
 	<ItemGroup>
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
 	  <PackageReference Include="FluentValidation" Version="12.1.1" />
-	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.10" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 	  <PackageReference Include="Serilog" Version="4.3.1" />
 	  <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
 	  <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 6/src/02. Step 1/DataAccess/DataAccess.csproj
+++ b/Phase 6/src/02. Step 1/DataAccess/DataAccess.csproj
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 6/src/02. Step 1/Test/Test.csproj
+++ b/Phase 6/src/02. Step 1/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 6/src/03. Step 2/Api/Api.csproj
+++ b/Phase 6/src/03. Step 2/Api/Api.csproj
@@ -18,7 +18,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 6/src/03. Step 2/Common/Common.csproj
+++ b/Phase 6/src/03. Step 2/Common/Common.csproj
@@ -15,8 +15,8 @@
 	<ItemGroup>
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
 	  <PackageReference Include="FluentValidation" Version="12.1.1" />
-	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.10" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 	  <PackageReference Include="Serilog" Version="4.3.1" />
 	  <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
 	  <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 6/src/03. Step 2/DataAccess/DataAccess.csproj
+++ b/Phase 6/src/03. Step 2/DataAccess/DataAccess.csproj
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 6/src/03. Step 2/Test/Test.csproj
+++ b/Phase 6/src/03. Step 2/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 7/src/01. StartSolution/Api/Api.csproj
+++ b/Phase 7/src/01. StartSolution/Api/Api.csproj
@@ -18,7 +18,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 7/src/01. StartSolution/Common/Common.csproj
+++ b/Phase 7/src/01. StartSolution/Common/Common.csproj
@@ -15,8 +15,8 @@
 	<ItemGroup>
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
 	  <PackageReference Include="FluentValidation" Version="12.1.1" />
-	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.10" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 	  <PackageReference Include="Serilog" Version="4.3.1" />
 	  <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
 	  <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 7/src/01. StartSolution/DataAccess/DataAccess.csproj
+++ b/Phase 7/src/01. StartSolution/DataAccess/DataAccess.csproj
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 7/src/01. StartSolution/Test/Test.csproj
+++ b/Phase 7/src/01. StartSolution/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 7/src/02. Step 1/Api/Api.csproj
+++ b/Phase 7/src/02. Step 1/Api/Api.csproj
@@ -18,8 +18,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-		<PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+		<PackageReference Include="Microsoft.OpenApi" Version="3.5.3" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 7/src/02. Step 1/Common/Common.csproj
+++ b/Phase 7/src/02. Step 1/Common/Common.csproj
@@ -15,8 +15,8 @@
 	<ItemGroup>
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
 	  <PackageReference Include="FluentValidation" Version="12.1.1" />
-	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.10" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 	  <PackageReference Include="Serilog" Version="4.3.1" />
 	  <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
 	  <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 7/src/02. Step 1/DataAccess/DataAccess.csproj
+++ b/Phase 7/src/02. Step 1/DataAccess/DataAccess.csproj
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 7/src/02. Step 1/Test/Test.csproj
+++ b/Phase 7/src/02. Step 1/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 7/src/02. Step 1/Utilities/Utilities.csproj
+++ b/Phase 7/src/02. Step 1/Utilities/Utilities.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/Phase 7/src/03. Step 2/Api/Api.csproj
+++ b/Phase 7/src/03. Step 2/Api/Api.csproj
@@ -17,8 +17,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-		<PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+		<PackageReference Include="Microsoft.OpenApi" Version="3.5.3" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 7/src/03. Step 2/Common/Common.csproj
+++ b/Phase 7/src/03. Step 2/Common/Common.csproj
@@ -15,8 +15,8 @@
 	<ItemGroup>
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
 	  <PackageReference Include="FluentValidation" Version="12.1.1" />
-	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.10" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 	  <PackageReference Include="Serilog" Version="4.3.1" />
 	  <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
 	  <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 7/src/03. Step 2/DataAccess/DataAccess.csproj
+++ b/Phase 7/src/03. Step 2/DataAccess/DataAccess.csproj
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 7/src/03. Step 2/Test/Test.csproj
+++ b/Phase 7/src/03. Step 2/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 7/src/03. Step 2/Utilities/Utilities.csproj
+++ b/Phase 7/src/03. Step 2/Utilities/Utilities.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/Phase 7/src/04. Step 3/Api/Api.csproj
+++ b/Phase 7/src/04. Step 3/Api/Api.csproj
@@ -18,8 +18,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
-		<PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+		<PackageReference Include="Microsoft.OpenApi" Version="3.5.3" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 7/src/04. Step 3/Common/Common.csproj
+++ b/Phase 7/src/04. Step 3/Common/Common.csproj
@@ -10,8 +10,8 @@
 
 	<ItemGroup>
 	  <PackageReference Include="FluentValidation" Version="12.1.1" />
-	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.10" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 	  <PackageReference Include="Serilog" Version="4.3.1" />
 	  <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
 	  <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 7/src/04. Step 3/DataAccess/DataAccess.csproj
+++ b/Phase 7/src/04. Step 3/DataAccess/DataAccess.csproj
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 7/src/04. Step 3/Scheduler/Scheduler.csproj
+++ b/Phase 7/src/04. Step 3/Scheduler/Scheduler.csproj
@@ -29,9 +29,9 @@
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.23" />
     <PackageReference Include="Hangfire.InMemory" Version="1.0.0" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
     <PackageReference Include="MediatR" Version="14.1.0" />

--- a/Phase 7/src/04. Step 3/Test/Test.csproj
+++ b/Phase 7/src/04. Step 3/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 7/src/04. Step 3/Utilities/Utilities.csproj
+++ b/Phase 7/src/04. Step 3/Utilities/Utilities.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/Phase 7/src/04. Step 4/Api/Api.csproj
+++ b/Phase 7/src/04. Step 4/Api/Api.csproj
@@ -18,7 +18,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 7/src/04. Step 4/Common/Common.csproj
+++ b/Phase 7/src/04. Step 4/Common/Common.csproj
@@ -11,8 +11,8 @@
 	<ItemGroup>
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
 	  <PackageReference Include="FluentValidation" Version="12.1.1" />
-	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.10" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 	  <PackageReference Include="Serilog" Version="4.3.1" />
 	  <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
 	  <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 7/src/04. Step 4/DataAccess/DataAccess.csproj
+++ b/Phase 7/src/04. Step 4/DataAccess/DataAccess.csproj
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 7/src/04. Step 4/Scheduler/Scheduler.csproj
+++ b/Phase 7/src/04. Step 4/Scheduler/Scheduler.csproj
@@ -23,9 +23,9 @@
     <PackageReference Include="Hangfire.Core" Version="1.8.23" />
     <PackageReference Include="Hangfire.InMemory" Version="1.0.0" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />

--- a/Phase 7/src/04. Step 4/Test/Test.csproj
+++ b/Phase 7/src/04. Step 4/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 7/src/04. Step 4/Utilities/Utilities.csproj
+++ b/Phase 7/src/04. Step 4/Utilities/Utilities.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/Phase 8/API Solution/Api/Api.csproj
+++ b/Phase 8/API Solution/Api/Api.csproj
@@ -18,7 +18,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 8/API Solution/Common/Common.csproj
+++ b/Phase 8/API Solution/Common/Common.csproj
@@ -11,8 +11,8 @@
 	<ItemGroup>
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
 	  <PackageReference Include="FluentValidation" Version="12.1.1" />
-	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.10" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 	  <PackageReference Include="Serilog" Version="4.3.1" />
 	  <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
 	  <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 8/API Solution/DataAccess/DataAccess.csproj
+++ b/Phase 8/API Solution/DataAccess/DataAccess.csproj
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 8/API Solution/Scheduler/Scheduler.csproj
+++ b/Phase 8/API Solution/Scheduler/Scheduler.csproj
@@ -23,9 +23,9 @@
     <PackageReference Include="Hangfire.Core" Version="1.8.23" />
     <PackageReference Include="Hangfire.InMemory" Version="1.0.0" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />

--- a/Phase 8/API Solution/Test/Test.csproj
+++ b/Phase 8/API Solution/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 8/API Solution/Utilities/Utilities.csproj
+++ b/Phase 8/API Solution/Utilities/Utilities.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/Phase 8/src/01. StartSolution/Api/Api.csproj
+++ b/Phase 8/src/01. StartSolution/Api/Api.csproj
@@ -18,7 +18,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 8/src/01. StartSolution/Common/Common.csproj
+++ b/Phase 8/src/01. StartSolution/Common/Common.csproj
@@ -11,8 +11,8 @@
 	<ItemGroup>
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
 	  <PackageReference Include="FluentValidation" Version="12.1.1" />
-	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.10" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 	  <PackageReference Include="Serilog" Version="4.3.1" />
 	  <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
 	  <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 8/src/01. StartSolution/DataAccess/DataAccess.csproj
+++ b/Phase 8/src/01. StartSolution/DataAccess/DataAccess.csproj
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 8/src/01. StartSolution/Scheduler/Scheduler.csproj
+++ b/Phase 8/src/01. StartSolution/Scheduler/Scheduler.csproj
@@ -23,9 +23,9 @@
     <PackageReference Include="Hangfire.Core" Version="1.8.23" />
     <PackageReference Include="Hangfire.InMemory" Version="1.0.0" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />

--- a/Phase 8/src/01. StartSolution/Test/Test.csproj
+++ b/Phase 8/src/01. StartSolution/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 8/src/01. StartSolution/Utilities/Utilities.csproj
+++ b/Phase 8/src/01. StartSolution/Utilities/Utilities.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/Phase 8/src/02. EndSolution/Api/Api.csproj
+++ b/Phase 8/src/02. EndSolution/Api/Api.csproj
@@ -18,7 +18,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
 		<PackageReference Include="NSwag.AspNetCore" Version="14.7.1" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>

--- a/Phase 8/src/02. EndSolution/Common/Common.csproj
+++ b/Phase 8/src/02. EndSolution/Common/Common.csproj
@@ -11,9 +11,9 @@
 	<ItemGroup>
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
 	  <PackageReference Include="FluentValidation" Version="12.1.1" />
-        <PackageReference Include="LiteBus" Version="4.3.0" />
-	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+        <PackageReference Include="LiteBus" Version="4.4.0" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.10" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 	  <PackageReference Include="Serilog" Version="4.3.1" />
 	  <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
 	  <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 8/src/02. EndSolution/DataAccess/DataAccess.csproj
+++ b/Phase 8/src/02. EndSolution/DataAccess/DataAccess.csproj
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 8/src/02. EndSolution/Scheduler/Scheduler.csproj
+++ b/Phase 8/src/02. EndSolution/Scheduler/Scheduler.csproj
@@ -23,10 +23,10 @@
     <PackageReference Include="Hangfire.Core" Version="1.8.23" />
     <PackageReference Include="Hangfire.InMemory" Version="1.0.0" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageReference Include="Microsoft.OpenApi" Version="3.5.3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />

--- a/Phase 8/src/02. EndSolution/Test/Test.csproj
+++ b/Phase 8/src/02. EndSolution/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 8/src/02. EndSolution/Utilities/Utilities.csproj
+++ b/Phase 8/src/02. EndSolution/Utilities/Utilities.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/Phase 8/src/03. MVC/Api/Api.csproj
+++ b/Phase 8/src/03. MVC/Api/Api.csproj
@@ -17,7 +17,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
 		<PackageReference Include="NSwag.AspNetCore" Version="14.7.1" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 			<PrivateAssets>all</PrivateAssets>

--- a/Phase 8/src/03. MVC/Common/Common.csproj
+++ b/Phase 8/src/03. MVC/Common/Common.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	  <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
 	  <PackageReference Include="Serilog" Version="4.3.1" />
 	  <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/Phase 8/src/03. MVC/DataAccess/DataAccess.csproj
+++ b/Phase 8/src/03. MVC/DataAccess/DataAccess.csproj
@@ -8,9 +8,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 8/src/03. MVC/Scheduler/Scheduler.csproj
+++ b/Phase 8/src/03. MVC/Scheduler/Scheduler.csproj
@@ -20,9 +20,9 @@
 		<PackageReference Include="Hangfire.Core" Version="1.8.23" />
 		<PackageReference Include="Hangfire.InMemory" Version="1.0.0" />
 		<PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.15" />
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.15" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />

--- a/Phase 8/src/03. MVC/Test/Test.csproj
+++ b/Phase 8/src/03. MVC/Test/Test.csproj
@@ -17,7 +17,7 @@
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
 		<PackageReference Include="LazyCache" Version="2.4.0" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 	</ItemGroup>

--- a/Phase 9/src/01. StartSolution/Api/Api.csproj
+++ b/Phase 9/src/01. StartSolution/Api/Api.csproj
@@ -18,7 +18,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
 		<PackageReference Include="NSwag.AspNetCore" Version="14.7.1" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>

--- a/Phase 9/src/01. StartSolution/Common/Common.csproj
+++ b/Phase 9/src/01. StartSolution/Common/Common.csproj
@@ -11,9 +11,9 @@
 	<ItemGroup>
         <PackageReference Include="Riok.Mapperly" Version="4.3.1" />
 	  <PackageReference Include="FluentValidation" Version="12.1.1" />
-        <PackageReference Include="LiteBus" Version="4.3.0" />
-	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+        <PackageReference Include="LiteBus" Version="4.4.0" />
+	  <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.10" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 	  <PackageReference Include="Serilog" Version="4.3.1" />
 	  <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
 	  <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 9/src/01. StartSolution/DataAccess/DataAccess.csproj
+++ b/Phase 9/src/01. StartSolution/DataAccess/DataAccess.csproj
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 9/src/01. StartSolution/Scheduler/Scheduler.csproj
+++ b/Phase 9/src/01. StartSolution/Scheduler/Scheduler.csproj
@@ -23,10 +23,10 @@
     <PackageReference Include="Hangfire.Core" Version="1.8.23" />
     <PackageReference Include="Hangfire.InMemory" Version="1.0.0" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageReference Include="Microsoft.OpenApi" Version="3.5.3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />

--- a/Phase 9/src/01. StartSolution/Test/Test.csproj
+++ b/Phase 9/src/01. StartSolution/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
-		<PackageReference Include="nunit" Version="4.6.0" />
+		<PackageReference Include="nunit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 9/src/01. StartSolution/Utilities/Utilities.csproj
+++ b/Phase 9/src/01. StartSolution/Utilities/Utilities.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>

--- a/Phase 9/src/02. FinalSolution/Api/Api.csproj
+++ b/Phase 9/src/02. FinalSolution/Api/Api.csproj
@@ -13,13 +13,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.0" />
-        <PackageReference Include="Magick.NET.Core" Version="14.13.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+        <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.1" />
+        <PackageReference Include="Magick.NET.Core" Version="14.13.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
-        <PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
+        <PackageReference Include="Microsoft.OpenApi" Version="3.5.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Phase 9/src/02. FinalSolution/Common/Common.csproj
+++ b/Phase 9/src/02. FinalSolution/Common/Common.csproj
@@ -8,11 +8,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoMapper" Version="12.0.0" />
+        <PackageReference Include="AutoMapper" Version="16.1.1" />
         <PackageReference Include="FluentValidation" Version="12.1.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/Phase 9/src/02. FinalSolution/Core/Core.csproj
+++ b/Phase 9/src/02. FinalSolution/Core/Core.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
         <PackageReference Include="SendGrid" Version="9.29.3" />
-        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
+        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 9/src/02. FinalSolution/DataAccess/DataAccess.csproj
+++ b/Phase 9/src/02. FinalSolution/DataAccess/DataAccess.csproj
@@ -9,12 +9,12 @@
 
     <ItemGroup>
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Phase 9/src/02. FinalSolution/Test/Test.csproj
+++ b/Phase 9/src/02. FinalSolution/Test/Test.csproj
@@ -17,8 +17,8 @@
 
     <ItemGroup>
         <PackageReference Include="Bogus" Version="35.6.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-        <PackageReference Include="nunit" Version="4.6.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+        <PackageReference Include="nunit" Version="4.6.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Phase 9/src/02. FinalSolution/Utilities/Utilities.csproj
+++ b/Phase 9/src/02. FinalSolution/Utilities/Utilities.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.10" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Update NuGet package versions across many csproj files to align dependencies and pick up patch/minor fixes. Notable changes: EF Core packages and related Microsoft.AspNetCore/Extensions packages moved from 10.0.7 to 10.0.8, Magick.NET 14.13.0 -> 14.13.1, AutoMapper updated (12.x -> 16.1.1), Microsoft.OpenApi 2.4.1 -> 3.5.3, Aspire.Hosting 13.3.0 -> 13.3.5, NUnit 4.6.0 -> 4.6.1, and several other complementary bumps. Applied across multiple Phase*/src/*/*.csproj files for consistency.